### PR TITLE
reduced the django docker image size

### DIFF
--- a/docker/django/Dockerfile.prod
+++ b/docker/django/Dockerfile.prod
@@ -9,33 +9,16 @@ ENV PYTHONPATH=/usr/src/rh/src
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \
-    build-essential cron \
-    libpq-dev curl man wget \
-    npm \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    curl cron \
+    # TODO: This adds 1.3GB to layers
+    npm nodejs && \
+    apt-get clean && \
+    npm cache clean -f && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies
 RUN pip install poetry
-
-# npm and node latest with n
-RUN npm cache clean -f
-RUN npm install -g n
-RUN n stable
-
-# Set the working directory
-WORKDIR /usr/src/rh
-
-# to preserve the docker cache
-COPY ["README.md", "Makefile", "poetry.lock","pyproject.toml","/usr/src/rh"]
-RUN poetry install --without dev --no-root --no-directory
-
-# copy project code -> src to /usr/src/rh/src
-COPY src /usr/src/rh/src
-
-# Install Node.js dependencies and build static files
-# Activate shell for django-vite-plugin build
-RUN poetry run make npm-install
 
 COPY docker/django/django-entrypoint.sh /usr/src/rh/django-entrypoint.sh
 RUN chmod a+x /usr/src/rh/django-entrypoint.sh
@@ -44,9 +27,25 @@ COPY docker/django/rh-tasks-cron /etc/cron.d/rh-tasks-cron
 RUN chmod 0644 /etc/cron.d/rh-tasks-cron
 RUN crontab /etc/cron.d/rh-tasks-cron
 RUN touch /var/log/cron.log
-RUN service cron start
+
+# to preserve the docker cache
+COPY ["README.md", "Makefile", "poetry.lock","pyproject.toml","/usr/src/rh/"]
+# COPY ["src/static/package.json","src/static/vite.config.js","src/static/package-lock.json","/usr/src/rh/src/static/"]
+
+# Set the working directory
+WORKDIR /usr/src/rh
+RUN poetry install --without dev --no-root --no-interaction --no-directory --no-ansi
+# copy project code -> src to /usr/src/rh/src
+COPY src /usr/src/rh/src
+
+# DEBUG should be False by default in production.py file, vite.config.js file should have production settings
+RUN poetry run make npm-install && \
+    poetry run make npm-build && \
+    npm cache clean --force && \
+    rm -rf /root/.npm && \
+    rm -rf src/static/node_modules
 
 ENTRYPOINT ["/usr/src/rh/django-entrypoint.sh"]
 
 # Gunicorn will be used to run the server
-CMD ["gunicorn", "--bind", "0.0.0.0:8000","--workers=4","src.core.wsgi:application"]
+CMD ["gunicorn", "--bind", "0.0.0.0:8000","--error-logfile","-","--workers=4","src.core.wsgi:application"]

--- a/docker/django/django-entrypoint.sh
+++ b/docker/django/django-entrypoint.sh
@@ -6,16 +6,13 @@ set -e
 echo "Preparing Django Application"
 
 # static files
-make collectstatic settings=core.settings.production
-echo "DEBUG: $DEBUG"
-make npm-build
-# rm -rf src/static/node_modules
+poetry run python src/manage.py collectstatic --settings=core.settings.production --no-input --ignore=node_modules --ignore=*.scss --ignore=*.json --ignore=vite.config.js
 
 # Create super user
 # Password is set in the env file. variable DJANGO_SUPERUSER_PASSWORD 
 poetry run python src/manage.py createsuperuser --username=admin --email=admin@admin.com --no-input --setting=core.settings.production || true
 
 # database
-make migrate
+poetry run python src/manage.py migrate
 
 exec "$@"

--- a/src/core/settings/production.py
+++ b/src/core/settings/production.py
@@ -3,6 +3,8 @@ from .base import *
 
 APP_ENV = env("APP_ENV", default="production")
 
+DEBUG = env("DEBUG", default=False)
+
 # ALLOWED_HOSTS=reporthub.immap.org,www.reporthub.immap.org
 # env.list() splits comma-separated string into a list
 ALLOWED_HOSTS = env.list(

--- a/src/static/vite.config.js
+++ b/src/static/vite.config.js
@@ -13,7 +13,7 @@ export default defineConfig({
         // relative to the folder that vite.config is located
         // "../users/static/users/users.js",
       ],
-      // pyArgs: ["--settings=core.settings.production"],
+      pyArgs: ["--settings=core.settings.production"],
       root: "..",
     }),
   ],


### PR DESCRIPTION
Reduced images size by 600MB.

> [!IMPORTANT]
> The node and npm installation adds 1.3GB to the layer
> Fixes
> - Multi stage build
> - Remove the node and npm build step and have the build files(Only SCSS) in the git